### PR TITLE
Make synced dir use project name on host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,5 @@ builds/virtualbox/*.ovf
 builds/virtualbox/*.vmdk
 builds/virtualbox/*/
 vagrant/base/.vagrant
-vagrant/hyrax/.vagrant
-vagrant/hyrax/vm
-vagrant/hyrax/vagrant-config.yaml
+vagrant/hyrax/*
+!vagrant/hyrax/Vagrantfile

--- a/vagrant/hyrax/Vagrantfile
+++ b/vagrant/hyrax/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
   config.vm.network "forwarded_port", guest: 8080, host: 8181
   config.vm.network "forwarded_port", guest: 8983, host: 8983
 
-  config.vm.synced_folder "vm/", "/home/vagrant/" + configs['project_name'], create: true, type: "sshfs", reverse: true
+  config.vm.synced_folder configs['project_name'], "/home/vagrant/" + configs['project_name'], create: true, type: "sshfs", reverse: true
 
   config.ssh.forward_agent = true
   config.ssh.shell="bash"


### PR DESCRIPTION
Right now the synced dir uses a generic 'vm' but it would be nice to be more explicit about what it is. Using the project name does that.