### PR TITLE
Update ports

### DIFF
--- a/vagrant/hyrax/Vagrantfile
+++ b/vagrant/hyrax/Vagrantfile
@@ -19,7 +19,8 @@ end
 Vagrant.configure("2") do |config|
   config.vm.box = configs['project_owner'] + "/" + configs['project_name']
   config.vm.network "forwarded_port", guest: 80, host: 8080
-  config.vm.network "forwarded_port", guest: 8080, host: 8181
+  config.vm.network "forwarded_port", guest: 80, host: 3000
+  config.vm.network "forwarded_port", guest: 8080, host: 8984
   config.vm.network "forwarded_port", guest: 8983, host: 8983
 
   config.vm.synced_folder configs['project_name'], "/home/vagrant/" + configs['project_name'], create: true, type: "sshfs", reverse: true


### PR DESCRIPTION
Change the Vagrant exposed ports to what the Samvera/Hyrax documentation says for development environments. This doesn't change the ports they're running at inside the VM. It does make what the developer sees closer to the upstream Samvera documentation though.

I am still keeping the web server mapped to ports 3000 and 8080 on the host machine. 3000 is what a RAILS person would expect, while 8080 is more generic.

There needs to be some documentation for #39, but #36 needs to be merged first since that reworked some of the README's structure.

Connected to #39 